### PR TITLE
ensure yarn packages are up to install when deploying

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'jbuilder', '~> 2.7'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 
+gem 'okcomputer' # monitors application and its dependencies
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
+    okcomputer (1.18.4)
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
@@ -336,6 +337,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.11)
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  okcomputer
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 7)

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'okcomputer'
+
+# /status for 'upness', e.g. for load balancer
+# /status/all to show all dependencies
+# /status/<name-of-check> for a specific check (e.g. for nagios warning)
+OkComputer.mount_at = 'status'
+OkComputer.check_in_parallel = true

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -51,6 +51,9 @@ development:
   <<: *default
   compile: true
 
+  # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
+  check_yarn_integrity: false
+
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
     https: false

--- a/lib/capistrano/tasks/yarn.rake
+++ b/lib/capistrano/tasks/yarn.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+desc 'Install Javascript dependencies via `yarn`'
+task :yarn_install do
+  on roles(:web) do
+    within release_path do
+      execute("cd #{release_path} && yarn install")
+    end
+  end
+end
+
+before 'deploy:assets:precompile', 'yarn_install'


### PR DESCRIPTION
Required so that we can deploy correctly (otherwise you get failures when it tries to precompile assets)

Also, add okcomputer gem so we can at least get a simple status check for sdr-deploy to ensure the application is up