### PR TITLE
Remove capistrano-rvm dependency

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -36,7 +36,6 @@ install_plugin Capistrano::SCM::Git
 # require "capistrano/rails/migrations"
 # require "capistrano/passenger"
 
-require 'capistrano/rvm'
 require 'capistrano/bundler'
 require 'capistrano/rails'
 require 'capistrano/maintenance'

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,6 @@ group :deployment do
   gem 'capistrano-maintenance', '~> 1.2', require: false
   gem 'capistrano-passenger', require: false
   gem 'capistrano-rails', require: false
-  gem 'capistrano-rvm', require: false
   gem 'dlss-capistrano', require: false
   gem 'capistrano'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,9 +99,6 @@ GEM
     capistrano-rails (1.6.2)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     capybara (3.37.1)
       addressable
@@ -318,7 +315,6 @@ DEPENDENCIES
   capistrano-maintenance (~> 1.2)
   capistrano-passenger
   capistrano-rails
-  capistrano-rvm
   capybara (>= 3.26)
   dlss-capistrano
   jbuilder (~> 2.7)
@@ -342,4 +338,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.3.17
+   2.3.22


### PR DESCRIPTION
This commit removes capistrano-rvm, a dependency we no longer need. Done because it is on the FR board.

Tested by deploying to stage
